### PR TITLE
Cleanup Dockerfile

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,13 @@
+name: Docker Image CI
+
+on: push
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Build the Docker image
+      run: docker build -t krypton-org/krypton-auth .
+    - name: Test the Docker image
+      run: ./test.sh

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # krypton-docker
 
+[![Docker Image CI](https://github.com/krypton-org/krypton-docker/workflows/Docker%20Image%20CI/badge.svg)](https://github.com/krypton-org/krypton-docker/actions)
+
 ### Quick Start
 
 Example setup with a single Krypton Authentication instance:

--- a/README.md
+++ b/README.md
@@ -1,20 +1,8 @@
 # krypton-docker
 
-### Build
+### Quick Start
 
-```bash
-# Pull the image from Docker Hub
-docker pull krypton-org/krypton-auth
-
-# Or build the image locally
-git clone git@github.com:krypton-org/krypton-docker.git
-cd krypton-docker
-docker build -t krypton-org/krypton-auth .
-```
-
-### Run
-
-Example setup with a single auth service instance:
+Example setup with a single Krypton Authentication instance:
 
 ```bash
 docker network create krypton-auth-net
@@ -29,14 +17,21 @@ docker run \
     --detach \
     --name krypton-auth \
     --network krypton-auth-net \
-    --env MONGODB_URI="mongodb://krypton-auth-db:27017/users"
+    --env MONGODB_URI="mongodb://krypton-auth-db:27017/users" \
     --publish 5000:5000 \
-    krypton-auth
+    krypton-org/krypton-auth
+```
 
+Test the service:
+
+```bash
 curl localhost:5000
-# {"notifications":[{"type":"success","message":"Welcome to GraphQL Auth Service - version 1.1.0"}]}
+# {"errors":[{"message":"Must provide query string.","type":"BadRequestError"}]}
+```
 
-# Cleanup
+To cleanup:
+
+```bash
 docker rm -f krypton-auth
 docker rm -f krypton-auth-db
 docker network rm krypton-auth-net
@@ -57,4 +52,13 @@ docker run -d -e "MONGODB_URI=..." -p 5000:5000 -v /my/dir:/krypton-vol krypton-
 Name           | Default   | Description
 ---------------|-----------|------------
 MONGODB_URI    | -         | MongoDB URI (`mongodb://host:port/collection`)
+
+### Build
+
+```bash
+git clone git@github.com:krypton-org/krypton-docker.git
+cd krypton-docker
+docker build -t krypton-org/krypton-auth .
+```
+
 

--- a/README.md
+++ b/README.md
@@ -1,11 +1,60 @@
 # krypton-docker
 
+### Build
+
 ```bash
-docker run -it -p 27017:27017 mongo
+# Pull the image from Docker Hub
+docker pull krypton-org/krypton-auth
+
+# Or build the image locally
 git clone git@github.com:krypton-org/krypton-docker.git
 cd krypton-docker
-docker build --tag krypton-auth .
-docker run -it -d --entrypoint mongod --hostname MONGODB --name=MONGODB --net=bridge -p 27017:27017 -p 4000:80 mongo
-docker run -it -d -v /usr/share/krypton:/krypton-vol -e  --net container:MONGODB krypton-auth
-# Open a browser at localhost:4000 Krypton Authentication is set
+docker build -t krypton-org/krypton-auth .
 ```
+
+### Run
+
+Example setup with a single auth service instance:
+
+```bash
+docker network create krypton-auth-net
+
+docker run \
+    --detach \
+    --name krypton-auth-db \
+    --network krypton-auth-net \
+    mongo
+
+docker run \
+    --detach \
+    --name krypton-auth \
+    --network krypton-auth-net \
+    --env MONGODB_URI="mongodb://krypton-auth-db:27017/users"
+    --publish 5000:5000 \
+    krypton-auth
+
+curl localhost:5000
+# {"notifications":[{"type":"success","message":"Welcome to GraphQL Auth Service - version 1.1.0"}]}
+
+# Cleanup
+docker rm -f krypton-auth
+docker rm -f krypton-auth-db
+docker network rm krypton-auth-net
+```
+
+### Configuration
+
+To specify the configuration, bind a local directory to `/krypton-vol`:
+
+```bash
+docker run -d -e "MONGODB_URI=..." -p 5000:5000 -v /my/dir:/krypton-vol krypton-auth
+```
+
+**TODO: Document configuration file format.**
+
+### Environement Variables
+
+Name           | Default   | Description
+---------------|-----------|------------
+MONGODB_URI    | -         | MongoDB URI (`mongodb://host:port/collection`)
+

--- a/src/index.ts
+++ b/src/index.ts
@@ -32,7 +32,7 @@ if (process.env.ALLOWED_ORIGINS
 //Import possible krypton configuration from /krypton-vol
 let config;
 try {
-    config = require(process.env.VOLUME+"/krypton.config.js");
+    config = require("/krypton-vol/krypton.config.js");
 } catch(err) {
     config = {}
 }
@@ -40,10 +40,10 @@ try {
 //Set Krypton Authentication
 app.use(KryptonAuth({ 
     dbAddress: process.env.MONGODB_URI, 
-    privateKeyFilePath: process.env.KEYS_PATH+"/private-key",
-    publicKeyFilePath: process.env.KEYS_PATH+"/public-key",
+    privateKeyFilePath: "/krypton-vol/private-key",
+    publicKeyFilePath: "/krypton-vol/public-key",
     ...config
 }));
 
 //Start server
-app.listen(process.env.PORT, () => { console.log("Listening on port " + process.env.PORT) });
+app.listen(5000, () => { console.log("Listening on port 5000") });

--- a/test.sh
+++ b/test.sh
@@ -21,6 +21,7 @@ docker run \
     --publish 5000:5000 \
     krypton-org/krypton-auth
 
+sleep 3
 curl localhost:5000
 
 docker rm -f krypton-auth

--- a/test.sh
+++ b/test.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+
+set -o errexit
+set -o pipefail
+set -o nounset
+set -o xtrace
+
+docker network create krypton-auth-net
+
+docker run \
+    --detach \
+    --name krypton-auth-db \
+    --network krypton-auth-net \
+    mongo
+
+docker run \
+    --detach \
+    --name krypton-auth \
+    --network krypton-auth-net \
+    --env MONGODB_URI="mongodb://krypton-auth-db:27017/users" \
+    --publish 5000:5000 \
+    krypton-org/krypton-auth
+
+curl localhost:5000
+
+docker rm -f krypton-auth
+docker rm -f krypton-auth-db
+docker network rm krypton-auth-net


### PR DESCRIPTION
**Done**

- Use `node:12-alpine` base image to reduce image size (the `node:12` image is based on Debian).
- Use already existing `node` user instead of creating a new user.
- Run `npm prune` at the same time as `npm build`, otherwise it is useless to reduce the final image size since intermediate images are layered upon each other.
- Expose an unprivileged port number (5000) instead of 80; this doesn't change anything, but I feel like it's a better default... :-)
- No need to use an env. variable for the port since the mapping is specified by the user with the docker run `-p/--publish` option.
- Same as above for the `VOLUME` and `KEYS_PATH` env. The mapping is specified using the docker run `-v/--volume` option.
- Update build/pull/run instructions in the README.
- Use a dedicated network between the containers, to address them by container name.
- Add test script and corresponding CI workflow.

**TODO** (@jrebecchi)

- Review Dockerfile/README
- Update "Configuration" section
